### PR TITLE
[UI] 칩 컴포넌트 제작

### DIFF
--- a/apps/LiteBoard/src/app/page.tsx
+++ b/apps/LiteBoard/src/app/page.tsx
@@ -1,9 +1,12 @@
-import { Button } from '@LiteBoard/ui';
+import { Button, Chip } from '@LiteBoard/ui';
 
 export default function Home() {
   return (
     <div>
-      <Button color="blue">버튼</Button>
+      {/* <Button color="blue">버튼</Button> */}
+      <Chip color="blue" size="md" radius="md" variant="filled">
+        라벨
+      </Chip>
     </div>
   );
 }

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/util';
+import { cn } from '../../lib/util';
 import { cva, VariantProps } from 'class-variance-authority';
 import React from 'react';
 

--- a/packages/ui/src/components/Chip/Chip.stories.tsx
+++ b/packages/ui/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Chip } from './Chip';
+
+const meta: Meta<typeof Chip> = {
+  title: 'Components/Chip',
+  component: Chip,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['filled', 'weak'],
+    },
+    color: {
+      control: 'radio',
+      options: ['blue', 'green', 'red', 'black', 'gray'],
+    },
+    size: {
+      control: 'radio',
+      options: ['lg', 'md', 'sm'],
+    },
+    radius: {
+      control: 'radio',
+      options: ['max', 'md'],
+    },
+    children: { control: 'text' },
+  },
+  args: {
+    children: 'Example Chip',
+    variant: 'filled',
+    color: 'blue',
+    size: 'md',
+    radius: 'max',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex items-center justify-center">
+      <Chip {...args} />
+    </div>
+  ),
+};
+
+export const FilledVariants: Story = {
+  render: () => (
+    <div className="flex items-center justify-center">
+      <div className="flex flex-col gap-3">
+        <Chip size="lg" variant="filled" color="blue" radius="md">라벨</Chip>
+        <Chip size="md" variant="filled" color="green" radius="md">라벨</Chip>
+        <Chip size="sm" variant="filled" color="red" radius="md">라벨</Chip>
+        <Chip size="sm" variant="filled" color="black" radius="md">라벨</Chip>
+      </div>
+    </div>
+  ),
+  args: {
+    variant: 'filled',
+    size: 'md',
+    radius: 'max',
+  },
+};
+
+export const WeakVariants: Story = {
+  render: () => (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="flex flex-col gap-3">
+        <Chip variant="weak" color="blue">라벨</Chip>
+        <Chip variant="weak" color="green">라벨</Chip>
+        <Chip variant="weak" color="red">라벨</Chip>
+        <Chip variant="weak" color="black">라벨</Chip>
+      </div>
+    </div>
+  ),
+  args: {
+    variant: 'weak',
+    size: 'md',
+    radius: 'max',
+  },
+};

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { chipVariants } from './chipVariants';
+import { cn } from '../../lib/util';
+import { VariantProps } from 'class-variance-authority';
+
+export interface ChipProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>,
+    VariantProps<typeof chipVariants> {
+  children: React.ReactNode;
+}
+
+export const Chip = ({
+  variant,
+  color,
+  size,
+  radius,
+  className,
+  children,
+  ...props
+}: ChipProps) => {
+  return (
+    <div className={cn(chipVariants({ variant, color, size, radius }), className)} {...props}>
+      {children}
+    </div>
+  );
+};
+
+Chip.displayName = 'Chip';

--- a/packages/ui/src/components/Chip/chipVariants.ts
+++ b/packages/ui/src/components/Chip/chipVariants.ts
@@ -1,0 +1,64 @@
+import { cva } from 'class-variance-authority';
+
+export const chipVariants = cva(
+  'inline-flex items-center justify-center transition-colors whitespace-nowrap px-2 cursor-pointer',
+  {
+    variants: {
+      variant: {
+        filled: '',
+        weak: '',
+      },
+      color: {
+        blue: '',
+        green: '',
+        red: '',
+        black: '',
+        gray: '',
+      },
+      size: {
+        lg: 'h-8 text-T2',
+        md: 'h-7 text-T3',
+        sm: 'h-6 text-B3M',
+      },
+      radius: {
+        max: 'rounded-full',
+        md: 'rounded-[12px]',
+      },
+    },
+    compoundVariants: [
+      // Filled
+      { variant: 'filled', color: 'blue', class: 'bg-blue-500 text-white' },
+      { variant: 'filled', color: 'green', class: 'bg-green-500 text-white' },
+      { variant: 'filled', color: 'red', class: 'bg-red-500 text-white' },
+      { variant: 'filled', color: 'black', class: 'bg-neutral-800 text-white' },
+
+      // Weak with hover
+      {
+        variant: 'weak',
+        color: 'blue',
+        class: 'bg-blue-50 text-blue-500 hover:bg-blue-100',
+      },
+      {
+        variant: 'weak',
+        color: 'green',
+        class: 'bg-green-50 text-green-500 hover:bg-green-100',
+      },
+      {
+        variant: 'weak',
+        color: 'red',
+        class: 'bg-red-50 text-red-500 hover:bg-red-100',
+      },
+      {
+        variant: 'weak',
+        color: 'black',
+        class: 'bg-neutral-100 text-neutral-800 hover:bg-neutral-200',
+      },
+    ],
+    defaultVariants: {
+      variant: 'filled',
+      color: 'gray',
+      size: 'md',
+      radius: 'max', // 기본은 rounded-full
+    },
+  }
+);

--- a/packages/ui/src/components/Chip/index.ts
+++ b/packages/ui/src/components/Chip/index.ts
@@ -1,0 +1,1 @@
+export * from './Chip';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './Button';
+export * from './Chip';


### PR DESCRIPTION
# 🛠 구현 사항

- 칩 컴포넌트 제작
- 칩 스토리 작성

# ❓ 질문

- 질문 작성

# 📸 화면 캡처
<img width="1125" height="338" alt="스크린샷 2025-07-13 오전 2 40 00" src="https://github.com/user-attachments/assets/1530eba2-ed31-4d86-afe4-bc21c23f2347" />
<img width="1079" height="324" alt="스크린샷 2025-07-13 오전 2 40 14" src="https://github.com/user-attachments/assets/b3d3ba8e-ed71-44bb-914c-c7778b48f8a4" />
<img width="982" height="381" alt="스크린샷 2025-07-13 오전 2 40 20" src="https://github.com/user-attachments/assets/a84cb477-5640-4973-8475-6572ca53d32d" />


# 💬 리뷰 요구사항
- 칩에서 variant, color, size, radius로 props 기반 스타일 분기 처리가 가능하도록 구현했습니다.
- 스타일 변형 로직은 chipVariants로 분리해서 구현했습니다.