### PR TITLE
[FEAT] 초기 렌더링 위치 설정 날짜 무한 렌더링 좌우 스크롤 및 오늘 날짜 롤백 기능 추가

### DIFF
--- a/apps/LiteBoard/src/app/(dashboard)/_components/add-task.tsx
+++ b/apps/LiteBoard/src/app/(dashboard)/_components/add-task.tsx
@@ -1,13 +1,16 @@
 'use client';
-import { Button } from '@LiteBoard/ui';
+import { Button, ChevronIcon } from '@LiteBoard/ui';
+import { useTimelineScrollStore } from '../team/_components/stores/useTimelineScrollStore';
 
 const AddTask = () => {
   const handleAddTask = () => {
     console.log('테스크 추가하기');
   };
+  const scrollBy = useTimelineScrollStore((s) => s.scrollBy);
+  const scrollToToday = useTimelineScrollStore((s) => s.scrollToToday);
 
   return (
-    <div className="ml-11 w-[139px]">
+    <div className="flex justify-between items-center mr-7 ml-11">
       <Button
         color={'blue'}
         variant={'filled'}
@@ -17,6 +20,32 @@ const AddTask = () => {
       >
         테스크 추가하기
       </Button>
+      <div className="flex gap-2 justify-center items-center text-neutral-700">
+        <Button
+          variant={'outline'}
+          className="px-2 w-10 h-9"
+          radius={'roundCorner'}
+          onClick={() => scrollBy(-800)}
+        >
+          <ChevronIcon type="left" size={24} />
+        </Button>
+        <Button
+          variant={'outline'}
+          className="px-3 w-[52px] h-9 text-text-T2"
+          radius={'roundCorner'}
+          onClick={scrollToToday}
+        >
+          오늘
+        </Button>
+        <Button
+          variant={'outline'}
+          className="px-2 w-10 h-9"
+          radius={'roundCorner'}
+          onClick={() => scrollBy(800)}
+        >
+          <ChevronIcon type="right" />
+        </Button>
+      </div>
     </div>
   );
 };

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/atoms/timeline/timeline-day.tsx
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/atoms/timeline/timeline-day.tsx
@@ -20,7 +20,7 @@ const TimelineDay = ({ days }: { days: Date[] }) => {
         return (
           <div
             key={index}
-            className="relative flex justify-center items-center h-[46px]"
+            className="relative flex justify-center items-center h-[46px] select-none"
           >
             <span
               className={cn('w-5 text-center text-text-B3M text-neutral-600', {
@@ -31,9 +31,6 @@ const TimelineDay = ({ days }: { days: Date[] }) => {
             >
               {format(day, 'd')}
             </span>
-            {isNow && (
-              <div className="absolute z-50 -bottom-1 left-[16.5px] w-2 h-2 bg-red-500 rounded-full" />
-            )}
           </div>
         );
       })}

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/consts/timeline.ts
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/consts/timeline.ts
@@ -1,5 +1,13 @@
+// 타임라인 보드 격자 가로 세로 픽셀
 export const DAY_WIDTH_PX = 40 as const;
 export const DAY_HEIGHT_PX = 38 as const;
 
-export const START_DATE = '2025-08-01T00:00:00.000Z';
-export const END_DATE = '2025-12-31T23:59:59.999Z';
+// 초기 월 수
+export const INITIAL_MONTHS_BEFORE = 2 as const;
+export const INITIAL_MONTHS_AFTER = 2 as const;
+
+// 스크롤 시 추가로 로드할 날짜 수
+export const LOAD_MORE_THRESHOLD_DAYS = 30 as const;
+
+// 오늘 날짜의 초기 스크롤 위치 비율
+export const TODAY_POSITION_RATIO = 0.3 as const;

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/hooks/useGenerateDays.ts
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/hooks/useGenerateDays.ts
@@ -1,17 +1,123 @@
-import { transformDate } from '@/utils/transformDate';
-import { START_DATE, END_DATE } from '../consts/timeline';
-import { addDays } from 'date-fns';
+import {
+  INITIAL_MONTHS_BEFORE,
+  INITIAL_MONTHS_AFTER,
+  LOAD_MORE_THRESHOLD_DAYS,
+  DAY_WIDTH_PX,
+  TODAY_POSITION_RATIO,
+} from '../consts/timeline';
+import { addDays, subMonths, addMonths, differenceInDays } from 'date-fns';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 export const useGenerateDays = () => {
-  const days = [];
+  const [startDate, setStartDate] = useState(() => {
+    const today = new Date();
+    return subMonths(today, INITIAL_MONTHS_BEFORE);
+  });
 
-  let currentDate = transformDate(START_DATE);
-  const endDate = transformDate(END_DATE);
+  const [endDate, setEndDate] = useState(() => {
+    const today = new Date();
+    return addMonths(today, INITIAL_MONTHS_AFTER);
+  });
 
-  while (currentDate <= endDate) {
-    days.push(new Date(currentDate));
-    currentDate = addDays(currentDate, 1);
-  }
+  const scrollTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const scrollAdjustmentRef = useRef<number>(0);
 
-  return days;
+  // 날짜 생성 함수
+  const generateDays = useCallback((start: Date, end: Date) => {
+    const days = [];
+    let currentDate = new Date(start);
+
+    while (currentDate <= end) {
+      days.push(new Date(currentDate));
+      currentDate = addDays(currentDate, 1);
+    }
+
+    return days;
+  }, []);
+
+  const days = generateDays(startDate, endDate);
+
+  // 왼쪽으로 스크롤하여 과거 날짜 로드 함수
+  const loadMorePastDays = useCallback(() => {
+    const oldStartDate = startDate;
+    const newStartDate = subMonths(startDate, 1);
+
+    const addedDays = differenceInDays(oldStartDate, newStartDate);
+    const addedWidth = addedDays * DAY_WIDTH_PX;
+
+    scrollAdjustmentRef.current = addedWidth;
+
+    setStartDate(newStartDate);
+  }, [startDate]);
+
+  // 오른쪽으로 스크롤하여 미래 날짜 로드 함수
+  const loadMoreFutureDays = useCallback(() => {
+    const newEndDate = addMonths(endDate, 1);
+    setEndDate(newEndDate);
+  }, [endDate]);
+
+  // 스크롤 위치에 따라 새로운 기간 로드 함수
+  const handleScroll = useCallback(
+    (scrollLeft: number, containerWidth: number) => {
+      //기존 타이머가 설정되어있다면 초기화
+      if (scrollTimerRef.current) {
+        clearTimeout(scrollTimerRef.current);
+      }
+
+      // 과거, 미래 날짜 로드 디바운싱 처리
+      scrollTimerRef.current = setTimeout(() => {
+        if (scrollLeft < LOAD_MORE_THRESHOLD_DAYS * DAY_WIDTH_PX) {
+          loadMorePastDays();
+        }
+
+        const totalWidth = days.length * DAY_WIDTH_PX;
+        const scrollRight = scrollLeft + containerWidth;
+        const thresholdFromRight = LOAD_MORE_THRESHOLD_DAYS * DAY_WIDTH_PX;
+
+        if (scrollRight > totalWidth - thresholdFromRight) {
+          loadMoreFutureDays();
+        }
+      }, 10);
+    },
+    [days.length, loadMorePastDays, loadMoreFutureDays]
+  );
+
+  // 오늘 날짜의 초기 스크롤 위치 계산 함수
+  const getInitialScrollPosition = useCallback(() => {
+    const today = new Date();
+    const todayIndex = differenceInDays(today, startDate);
+    const todayPosition = todayIndex * DAY_WIDTH_PX;
+    const containerWidth = window.innerWidth * 0.7;
+    const targetPosition = containerWidth * TODAY_POSITION_RATIO;
+
+    return Math.max(0, todayPosition - targetPosition);
+  }, [startDate]);
+
+  // 스크롤 위치 조정값 가져오기 함수
+  // (과거 날짜 로드 후 앞쪽에 push 할 때 발생하는 스크롤 밀림 현상 방지)
+  const getScrollAdjustment = useCallback(() => {
+    const adjustment = scrollAdjustmentRef.current;
+    scrollAdjustmentRef.current = 0;
+    return adjustment;
+  }, []);
+
+  // 컴포넌트 언마운트 시 타이머 초기화
+  useEffect(() => {
+    return () => {
+      if (scrollTimerRef.current) {
+        clearTimeout(scrollTimerRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    days,
+    loadMorePastDays,
+    loadMoreFutureDays,
+    handleScroll,
+    getInitialScrollPosition,
+    getScrollAdjustment,
+    startDate,
+    endDate,
+  };
 };

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/molecules/timeline/timeline-board.tsx
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/molecules/timeline/timeline-board.tsx
@@ -1,17 +1,101 @@
+import { useRef, useEffect } from 'react';
 import TimelineMonth from '../../atoms/timeline/timline-month';
 import TimelineDay from '../../atoms/timeline/timeline-day';
 import TimelineGridPannel from './timeline-grid-pannel';
 import { Task } from '../../types/task';
+import { useTimelineScrollStore } from '../../stores/useTimelineScrollStore';
 
 interface TimelineBoardProps {
   days: Date[];
   tasks: Task[];
+  onScroll?: (scrollLeft: number, containerWidth: number) => void;
+  getInitialScrollPosition: () => number;
+  getScrollAdjustment: () => number;
 }
 
-const TimelineBoard = ({ days, tasks }: TimelineBoardProps) => {
+const TimelineBoard = ({
+  days,
+  tasks,
+  onScroll,
+  getInitialScrollPosition,
+  getScrollAdjustment,
+}: TimelineBoardProps) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null); // 타임라인 보드 DOM 객체
+  const isInitialRenderRef = useRef<boolean>(true); // 최초 렌더링 여부 플래그
+  const previousDaysLengthRef = useRef<number>(0);
+  const lastScrollLeftRef = useRef<number>(0);
+  const setScrollContainer = useTimelineScrollStore(
+    (s) => s.setScrollContainer
+  );
+  const setGetInitialScrollPosition = useTimelineScrollStore(
+    (s) => s.setGetInitialScrollPosition
+  );
+
+  // 최초 렌더링 시 스크롤 위치 초기화
+  useEffect(() => {
+    if (scrollContainerRef.current && isInitialRenderRef.current) {
+      const initialScrollPosition = getInitialScrollPosition();
+      scrollContainerRef.current.scrollLeft = initialScrollPosition;
+      lastScrollLeftRef.current = initialScrollPosition;
+      isInitialRenderRef.current = false;
+    }
+  }, [getInitialScrollPosition]);
+
+  // 타임라인 보드 DOM 전역 스토어에 저장
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      setScrollContainer(scrollContainerRef.current);
+      return () => setScrollContainer(null);
+    }
+  }, [setScrollContainer]);
+
+  // 전역 스토어에 초기 스크롤 위치 저장
+  useEffect(() => {
+    setGetInitialScrollPosition(getInitialScrollPosition);
+    return () => setGetInitialScrollPosition(null);
+  }, [getInitialScrollPosition, setGetInitialScrollPosition]);
+
+  useEffect(() => {
+    const currentDaysLength = days.length;
+    const previousDaysLength = previousDaysLengthRef.current;
+
+    if (
+      currentDaysLength > previousDaysLength &&
+      !isInitialRenderRef.current &&
+      scrollContainerRef.current
+    ) {
+      const adjustment = getScrollAdjustment();
+      if (adjustment > 0) {
+        const newScrollLeft = lastScrollLeftRef.current + adjustment;
+
+        setTimeout(() => {
+          if (scrollContainerRef.current) {
+            scrollContainerRef.current.scrollLeft = newScrollLeft;
+            lastScrollLeftRef.current = newScrollLeft;
+          }
+        }, 0);
+      }
+    }
+
+    previousDaysLengthRef.current = currentDaysLength;
+  }, [days.length, getScrollAdjustment]);
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    if (onScroll && scrollContainerRef.current) {
+      const { scrollLeft } = e.currentTarget;
+      lastScrollLeftRef.current = scrollLeft;
+      const containerWidth = scrollContainerRef.current.clientWidth;
+      onScroll(scrollLeft, containerWidth);
+    }
+  };
+
   return (
     <div className="flex overflow-hidden flex-col flex-1 h-full border-t border-neutral-200">
-      <div className="overflow-auto flex-1 scrollbar-thin scrollbar-thumb-neutral-200 scrollbar-track-transparent">
+      <div
+        ref={scrollContainerRef}
+        className="overflow-auto flex-1 scrollbar scrollbar-thumb-neutral-200 scrollbar-track-transparent"
+        onScroll={handleScroll}
+      >
         <div className="min-w-max">
           <TimelineMonth days={days} />
           <TimelineDay days={days} />

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/molecules/timeline/timeline-grid-pannel.tsx
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/molecules/timeline/timeline-grid-pannel.tsx
@@ -1,10 +1,11 @@
 import { cn } from '@utils/cn';
 import { isSaturday, isSunday } from 'date-fns';
 import { differenceInDays } from 'date-fns';
-import { DAY_HEIGHT_PX, DAY_WIDTH_PX, START_DATE } from '../../consts/timeline';
+import { DAY_HEIGHT_PX, DAY_WIDTH_PX } from '../../consts/timeline';
 import { Task } from '../../types/task';
 import TimelineTaskCard from '../../atoms/timeline/timeline-task-card';
 import { transformDate } from '@/utils/transformDate';
+import { useEffect, useState } from 'react';
 
 interface TimelineGridPannelProps {
   days: Date[];
@@ -12,69 +13,103 @@ interface TimelineGridPannelProps {
 }
 
 const TimelineGridPannel = ({ days, tasks }: TimelineGridPannelProps) => {
+  const [gridHeight, setGridHeight] = useState('500px');
+  const startDate = days[0] || new Date();
+
+  useEffect(() => {
+    // 디바이스 화면 높이에 따른 타임라인 보드 높이 계산 로직
+    const calculateGridHeight = () => {
+      const isSmallScreen = window.innerHeight < 1024;
+
+      const baseMargin = 236;
+      const extraMargin = isSmallScreen ? 150 : 50;
+
+      const availableHeight = window.innerHeight - baseMargin - extraMargin;
+      const calculatedHeight = Math.max(availableHeight, 200);
+
+      setGridHeight(`${calculatedHeight}px`);
+    };
+
+    calculateGridHeight();
+
+    window.addEventListener('resize', calculateGridHeight);
+    return () => window.removeEventListener('resize', calculateGridHeight);
+  }, []);
+
   return (
-    <div
-      className="grid relative pt-[46px]"
-      style={{
-        gridTemplateColumns: `repeat(${days.length}, ${DAY_WIDTH_PX}px)`,
-        gridTemplateRows: `repeat(15, ${DAY_HEIGHT_PX}px)`,
-        gap: '2px 0',
-        maxHeight: '660px',
-        overflowY: 'scroll',
-      }}
-    >
-      {Array.from({ length: 15 }, (_, rowIndex) =>
-        days.map((day, dayIndex) => {
-          const isSat = isSaturday(day);
-          const isSun = isSunday(day);
-
-          return (
-            <div
-              key={`${rowIndex}-${dayIndex}`}
-              className={cn(
-                'h-full border-t border-b border-l border-gray-100',
-                {
-                  'bg-neutral-50': isSat || isSun,
-                  'bg-neutral-white': !isSat && !isSun,
-                }
-              )}
-            ></div>
-          );
-        })
-      ).flat()}
-
-      {/* 태스크 바 렌더링 영역 */}
-      {tasks.map((task, taskIndex) => {
-        const startDayIndex = differenceInDays(
-          transformDate(task.startDate),
-          transformDate(START_DATE)
-        );
-        const duration =
-          differenceInDays(
-            transformDate(task.endDate),
-            transformDate(task.startDate)
-          ) + 1;
-        const left = startDayIndex * DAY_WIDTH_PX;
-        const width = duration * DAY_WIDTH_PX;
-
-        return (
-          <TimelineTaskCard
-            key={task.id}
-            task={task}
-            left={left}
-            width={width}
-            taskIndex={taskIndex}
-          />
-        );
-      })}
-
+    <div className="relative">
       {/* 오늘 날짜 체크 선 */}
       <div
-        className="absolute top-0 bottom-0 z-30 w-[1px] bg-red-400"
+        className="absolute z-50 w-2 h-2 bg-red-500 rounded-full pointer-events-none"
         style={{
-          left: `${differenceInDays(new Date(), transformDate(START_DATE)) * DAY_WIDTH_PX + DAY_WIDTH_PX / 2}px`,
+          top: '-3px',
+          left: `${differenceInDays(new Date(), startDate) * DAY_WIDTH_PX + DAY_WIDTH_PX / 2 - 3.5}px`,
         }}
       />
+      <div
+        className="absolute bottom-0 z-30 w-[1px] bg-red-400 pointer-events-none"
+        style={{
+          top: '-3px',
+          left: `${differenceInDays(new Date(), startDate) * DAY_WIDTH_PX + DAY_WIDTH_PX / 2}px`,
+        }}
+      />
+
+      {/* 그리드 패널 */}
+      <div
+        className="grid relative pt-[46px]"
+        style={{
+          gridTemplateColumns: `repeat(${days.length}, ${DAY_WIDTH_PX}px)`,
+          gridTemplateRows: `repeat(20, ${DAY_HEIGHT_PX}px)`,
+          gap: '2px 0',
+          maxHeight: gridHeight,
+          overflowY: 'scroll',
+        }}
+      >
+        {Array.from({ length: 20 }, (_, rowIndex) =>
+          days.map((day, dayIndex) => {
+            const isSat = isSaturday(day);
+            const isSun = isSunday(day);
+
+            return (
+              <div
+                key={`${rowIndex}-${dayIndex}`}
+                className={cn(
+                  'h-full border-t border-b border-l border-gray-100',
+                  {
+                    'bg-neutral-50': isSat || isSun,
+                    'bg-neutral-white': !isSat && !isSun,
+                  }
+                )}
+              ></div>
+            );
+          })
+        ).flat()}
+
+        {/* 태스크 바 렌더링 영역 */}
+        {tasks.map((task, taskIndex) => {
+          const startDayIndex = differenceInDays(
+            transformDate(task.startDate),
+            startDate
+          );
+          const duration =
+            differenceInDays(
+              transformDate(task.endDate),
+              transformDate(task.startDate)
+            ) + 1;
+          const left = startDayIndex * DAY_WIDTH_PX;
+          const width = duration * DAY_WIDTH_PX;
+
+          return (
+            <TimelineTaskCard
+              key={task.id}
+              task={task}
+              left={left}
+              width={width}
+              taskIndex={taskIndex}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/organisms/category/category-container.tsx
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/organisms/category/category-container.tsx
@@ -26,7 +26,7 @@ const categoryTaskList: { description: string; status: TaskStatus }[] = [
 
 const CategoryContainer = () => {
   return (
-    <div className="grid grid-rows-[93px_1fr] min-h-[752px] h-full w-[310px] bg-neutral-100 border-t border-r border-b border-neutral-200">
+    <div className="grid grid-rows-[93px_1fr] h-full w-[310px] bg-neutral-100 border-t border-r border-b border-neutral-200">
       <CategoryYearBox year={2025} />
 
       <div className="flex flex-col flex-shrink-0 px-5 py-4 gap-[2px]">

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/organisms/timeline/timeline-container.tsx
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/organisms/timeline/timeline-container.tsx
@@ -40,9 +40,18 @@ const tasks = [
 ];
 
 const TimelineContainer = () => {
-  const days = useGenerateDays();
+  const { days, handleScroll, getInitialScrollPosition, getScrollAdjustment } =
+    useGenerateDays();
 
-  return <TimelineBoard days={days} tasks={tasks} />;
+  return (
+    <TimelineBoard
+      days={days}
+      tasks={tasks}
+      onScroll={handleScroll}
+      getInitialScrollPosition={getInitialScrollPosition}
+      getScrollAdjustment={getScrollAdjustment}
+    />
+  );
 };
 
 export default TimelineContainer;

--- a/apps/LiteBoard/src/app/(dashboard)/team/_components/stores/useTimelineScrollStore.ts
+++ b/apps/LiteBoard/src/app/(dashboard)/team/_components/stores/useTimelineScrollStore.ts
@@ -1,0 +1,40 @@
+'use client';
+import { create } from 'zustand';
+
+interface TimelineScrollStore {
+  scrollContainer: HTMLDivElement | null;
+  setScrollContainer: (el: HTMLDivElement | null) => void;
+  scrollBy: (scrollPosition: number) => void;
+  scrollTo: (leftPx: number) => void;
+  getInitialScrollPosition: (() => number) | null;
+  setGetInitialScrollPosition: (fn: (() => number) | null) => void;
+  scrollToToday: () => void;
+}
+
+export const useTimelineScrollStore = create<TimelineScrollStore>(
+  (set, get) => ({
+    scrollContainer: null,
+    getInitialScrollPosition: null,
+    setScrollContainer: (el) => set({ scrollContainer: el }),
+    setGetInitialScrollPosition: (fn) => set({ getInitialScrollPosition: fn }),
+    scrollBy: (scrollPosition) => {
+      const el = get().scrollContainer;
+      if (el) {
+        el.scrollBy({ left: scrollPosition, behavior: 'smooth' });
+      }
+    },
+    scrollTo: (leftPx) => {
+      const el = get().scrollContainer;
+      if (el) {
+        el.scrollTo({ left: leftPx, behavior: 'smooth' });
+      }
+    },
+    scrollToToday: () => {
+      const el = get().scrollContainer;
+      const getPos = get().getInitialScrollPosition;
+      if (el && getPos) {
+        el.scrollTo({ left: getPos(), behavior: 'smooth' });
+      }
+    },
+  })
+);


### PR DESCRIPTION
# 🛠 구현 사항

- 최초 렌더링 시 위치 지정
- 과거 미래 날짜 무한 스크롤 로드 기능 구현
- 과거 미래 날짜 일정 기간 이동 기능 및 오늘 날짜 롤백 기능 구현

# ❓ 질문

# 📸 화면 캡처

https://github.com/user-attachments/assets/98de25ed-5b01-499d-a97e-2a7fcd5301d1


# 💬 리뷰 요구사항
- 스크롤 이벤트들을 필연적으로 사용을 하다보니 useEffect 사용이 많아졌는데 성능적인 부분이나 리팩토링 가능한 부분들 알려주시면 감사하겠습니다!
- 과거 날짜 로드하는 부분에서 스크롤로 불러오거나 버튼으로 불러올 때 살짝 끊기는 버그가 있는데 혹시 이 부분도 원인을 아신다면 공유 부탁드립니다 ㅜㅜ (여긴 나머지 작업들 하고 잡아볼게요,,)
